### PR TITLE
fix(ci): exécuter les tests sur l'architecture de la matriceFix/ci run platform

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Run tests
         run: |
-          docker run --rm moseiik-test
+          docker run --rm --platform ${{ matrix.platform }} moseiik-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            -t moseiik-test \
+            --load .
+
+      - name: Run tests
+        run: |
+          docker run --rm moseiik-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# On utilise l'image officielle de Rust
+FROM rust:latest
+
+# On crée notre dossier de travail dans le conteneur
+WORKDIR /usr/src/moseiik
+
+# On copie tout notre code (le .dockerignore bloquera le dossier target/)
+COPY . .
+
+# La commande qui s'exécutera automatiquement au lancement
+ENTRYPOINT [ "cargo", "test", "--release", "--" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,4 +451,37 @@ mod tests {
 
         fs::remove_file(input_path).unwrap();
     }
+
+    #[test]
+    fn unit_test_prepare_tiles() {
+        use std::fs;
+
+        let tiles_dir = "test_tiles";
+        fs::create_dir_all(tiles_dir).unwrap();
+
+        // Create two images with different sizes.
+        let tile1 = RgbImage::from_pixel(10, 10, Rgb([255, 0, 0]));
+        let tile2 = RgbImage::from_pixel(20, 20, Rgb([0, 255, 0]));
+
+        tile1.save(format!("{}/tile1.png", tiles_dir)).unwrap();
+        tile2.save(format!("{}/tile2.png", tiles_dir)).unwrap();
+
+        let tile_size = Size {
+            width: 5,
+            height: 5,
+        };
+
+        let tiles = prepare_tiles(tiles_dir, &tile_size, false).unwrap();
+
+        // Two images should be loaded.
+        assert_eq!(tiles.len(), 2);
+
+        // All images should be resized to 5x5.
+        for tile in tiles {
+            assert_eq!(tile.width(), 5);
+            assert_eq!(tile.height(), 5);
+        }
+
+        fs::remove_dir_all(tiles_dir).unwrap();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,4 +426,29 @@ mod tests {
 
         assert_eq!(l1_generic(&img1, &img2), 15);
     }
+
+        #[test]
+    fn unit_test_prepare_target() {
+        use std::fs;
+
+        // Create a temporary image whose dimensions are not multiples of tile_size.
+        let input_path = "test_prepare_target.png";
+        let image = RgbImage::from_pixel(7, 5, Rgb([255, 0, 0]));
+        image.save(input_path).unwrap();
+
+        let tile_size = Size {
+            width: 3,
+            height: 2,
+        };
+
+        let result = prepare_target(input_path, 2, &tile_size).unwrap();
+
+        // Original size: 7x5
+        // Cropped size: 6x4
+        // Scaled x2: 12x8
+        assert_eq!(result.width(), 12);
+        assert_eq!(result.height(), 8);
+
+        fs::remove_file(input_path).unwrap();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,9 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    // Import RGB image structures used for test image generation.
+    use image::{Rgb, RgbImage};
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn unit_test_x86() {
@@ -365,7 +368,22 @@ mod tests {
 
     #[test]
     fn unit_test_generic() {
-        // TODO
-        assert!(false);
+
+        // Case 1: two identical images.
+        // The L1 distance should be equal to 0.
+        let mut img1 = RgbImage::new(1, 1);
+        let mut img2 = RgbImage::new(1, 1);
+
+        img1.put_pixel(0, 0, Rgb([10, 20, 30]));
+        img2.put_pixel(0, 0, Rgb([10, 20, 30]));
+
+        assert_eq!(l1_generic(&img1, &img2), 0);
+
+        // Case 2: images with different RGB values.
+        // Expected distance:
+        // |10 - 15| + |20 - 25| + |30 - 35| = 15
+        img2.put_pixel(0, 0, Rgb([15, 25, 35]));
+
+        assert_eq!(l1_generic(&img1, &img2), 15);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,11 +352,32 @@ mod tests {
     use super::*;
     // Import RGB image structures used for test image generation.
     use image::{Rgb, RgbImage};
+
+    
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn unit_test_x86() {
-        // TODO
-        assert!(false);
+
+        // Case 1: same image.
+        // The L1 distance of an image with itself must be 0.
+        let im = RgbImage::from_pixel(5, 5, Rgb([100, 150, 200]));
+        assert_eq!(unsafe { l1_x86_sse2(&im, &im) }, 0);
+
+        // Case 2: known distance.
+        // 5x5 pixels * (|1-0| + |1-0| + |1-0|) = 75.
+        let im1 = RgbImage::from_pixel(5, 5, Rgb([0, 0, 0]));
+        let im2 = RgbImage::from_pixel(5, 5, Rgb([1, 1, 1]));
+        assert_eq!(unsafe { l1_x86_sse2(&im1, &im2) }, 75);
+
+        // Case 3: compare SSE2 result with the generic implementation.
+        // The optimized version must return the same distance.
+        let im1 = RgbImage::from_pixel(5, 5, Rgb([10, 20, 30]));
+        let im2 = RgbImage::from_pixel(5, 5, Rgb([40, 80, 120]));
+
+        let generic = l1_generic(&im1, &im2);
+        let sse2 = unsafe { l1_x86_sse2(&im1, &im2) };
+
+        assert_eq!(sse2, generic);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,7 @@ mod tests {
     // Import RGB image structures used for test image generation.
     use image::{Rgb, RgbImage};
 
-    
+
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn unit_test_x86() {
@@ -383,8 +383,27 @@ mod tests {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn unit_test_aarch64() {
-        // TODO
-        assert!(false);
+
+        // Case 1: same image.
+        // The L1 distance of an image with itself must be 0.
+        let im = RgbImage::from_pixel(5, 5, Rgb([100, 150, 200]));
+        assert_eq!(unsafe { l1_neon(&im, &im) }, 0);
+
+        // Case 2: known distance.
+        // 5x5 pixels * (|1-0| + |1-0| + |1-0|) = 75.
+        let im1 = RgbImage::from_pixel(5, 5, Rgb([0, 0, 0]));
+        let im2 = RgbImage::from_pixel(5, 5, Rgb([1, 1, 1]));
+        assert_eq!(unsafe { l1_neon(&im1, &im2) }, 75);
+
+        // Case 3: compare NEON result with the generic implementation.
+        // The optimized version must return the same distance.
+        let im1 = RgbImage::from_pixel(5, 5, Rgb([10, 20, 30]));
+        let im2 = RgbImage::from_pixel(5, 5, Rgb([40, 80, 120]));
+
+        let generic = l1_generic(&im1, &im2);
+        let neon = unsafe { l1_neon(&im1, &im2) };
+
+        assert_eq!(neon, generic);
     }
 
     #[test]

--- a/tests/temp.rs
+++ b/tests/temp.rs
@@ -1,23 +1,110 @@
+use image::io::Reader as ImageReader;
+use moseiik::main::{compute_mosaic, Options};
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    // Test spécifique pour les processeurs d'ordinateurs classiques (PC Windows/Linux)
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn test_x86() {
-        // TODO
-        // test avx2 or sse2 if available
-        assert!(false);
+    fn test_x86_matches_generic() {
+        // 1. On configure les paramètres pour forcer l'algorithme générique (sans accélération)
+        let args_generic = Options {
+            image: String::from("assets/target-small.png"), // Petite image pour que le test soit instantané
+            output: String::from("assets/out-generic-x86.png"),
+            tiles: String::from("assets/tiles-small"), // Petit set de vignettes
+            scaling: 1,
+            tile_size: 5,
+            remove_used: false,
+            verbose: false,
+            simd: false, // <-- TRÈS IMPORTANT : on désactive le SIMD
+            num_thread: 4, // On utilise 4 cœurs pour ne pas figer la machine
+        };
+        compute_mosaic(args_generic); // On génère l'image de référence interne
+
+        // 2. On configure les mêmes paramètres, mais cette fois avec le SIMD activé
+        let args_simd = Options {
+            image: String::from("assets/target-small.png"),
+            output: String::from("assets/out-simd-x86.png"),
+            tiles: String::from("assets/tiles-small"),
+            scaling: 1,
+            tile_size: 5,
+            remove_used: false,
+            verbose: false,
+            simd: true, // <-- TRÈS IMPORTANT : on active le SIMD (SSE2 sur x86)
+            num_thread: 4,
+        };
+        compute_mosaic(args_simd); // On génère l'image accélérée
+
+        // 3. Test différentiel : On recharge les deux images et on vérifie qu'elles sont égales
+        // Si le SIMD est bien codé, l'accélération matérielle ne doit pas modifier le résultat mathématique.
+        let img_generic = ImageReader::open("assets/out-generic-x86.png").unwrap().decode().unwrap().to_rgb8();
+        let img_simd = ImageReader::open("assets/out-simd-x86.png").unwrap().decode().unwrap().to_rgb8();
+
+        assert_eq!(img_generic, img_simd, "Erreur : L'optimisation x86 SSE2 modifie le résultat du calcul !");
     }
 
+    // Test spécifique pour les processeurs ARM (comme les Mac M1/M2/M3 ou les Raspberry Pi)
     #[test]
     #[cfg(target_arch = "aarch64")]
-    fn test_aarch64() {
-        //TODO
-        assert!(false);
+    fn test_aarch64_matches_generic() {
+        // Étape 1 : Génération classique (Sans NEON)
+        let args_generic = Options {
+            image: String::from("assets/target-small.png"),
+            output: String::from("assets/out-generic-arm.png"),
+            tiles: String::from("assets/tiles-small"),
+            scaling: 1,
+            tile_size: 5,
+            remove_used: false,
+            verbose: false,
+            simd: false, // Pas de SIMD
+            num_thread: 4,
+        };
+        compute_mosaic(args_generic);
+
+        // Étape 2 : Génération accélérée (Avec NEON)
+        let args_simd = Options {
+            image: String::from("assets/target-small.png"),
+            output: String::from("assets/out-simd-arm.png"),
+            tiles: String::from("assets/tiles-small"),
+            scaling: 1,
+            tile_size: 5,
+            remove_used: false,
+            verbose: false,
+            simd: true, // Activation de l'accélération matérielle ARM NEON
+            num_thread: 4,
+        };
+        compute_mosaic(args_simd);
+
+        // Étape 3 : Comparaison stricte
+        let img_generic = ImageReader::open("assets/out-generic-arm.png").unwrap().decode().unwrap().to_rgb8();
+        let img_simd = ImageReader::open("assets/out-simd-arm.png").unwrap().decode().unwrap().to_rgb8();
+
+        assert_eq!(img_generic, img_simd, "Erreur : L'optimisation ARM NEON modifie le résultat du calcul !");
     }
 
+    // Test de sécurité général (S'exécute sur toutes les machines)
     #[test]
-    fn test_generic() {
-        //TODO
-        assert!(false);
+    fn test_generic_execution_success() {
+        // Ce test s'assure simplement que le programme est capable de lire, calculer et sauvegarder 
+        // une image sans planter (Panic) en utilisant l'algorithme de base.
+        let args = Options {
+            image: String::from("assets/target-small.png"),
+            output: String::from("assets/out-generic.png"),
+            tiles: String::from("assets/tiles-small"),
+            scaling: 1,
+            tile_size: 5,
+            remove_used: false,
+            verbose: false,
+            simd: false,
+            num_thread: 4,
+        };
+        
+        compute_mosaic(args);
+
+        // On vérifie que le fichier a bien été créé et qu'il n'est pas vide
+        let generated = ImageReader::open("assets/out-generic.png").unwrap().decode().unwrap().to_rgb8();
+        assert!(generated.width() > 0 && generated.height() > 0, "L'image générée est vide !");
     }
 }


### PR DESCRIPTION
Le step Run tests lançait docker run sans --platform, donc le conteneur tournait toujours en amd64 (archi par défaut du runner). La ligne arm64 de la matrice construisait une image ARM mais exécutait du x86 → le test NEON test_aarch64_matches_generic n'était jamais réellement exécuté. Ajout de --platform ${{ matrix.platform }} pour que chaque architecture soit vraiment testée (arm64 via QEMU).